### PR TITLE
Downgrading typescript to ^4.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
 				"jsdom": "^23.1.0",
 				"postcss": "^8.4.22",
 				"tailwindcss": "^3.3.1",
-				"typescript": "^5.4.2",
+				"typescript": "^4.9.5",
 				"vite": "^4.2.0",
 				"vitest": "^1.1.3"
 			}
@@ -22968,15 +22968,15 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-			"integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=14.17"
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/ufo": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"jsdom": "^23.1.0",
 		"postcss": "^8.4.22",
 		"tailwindcss": "^3.3.1",
-		"typescript": "^5.4.2",
+		"typescript": "^4.9.5",
 		"vite": "^4.2.0",
 		"vitest": "^1.1.3"
 	}


### PR DESCRIPTION
Downgrading typescript to ^4.9.5 for compatability issues with react-scripts